### PR TITLE
Correct the created .env to match expected structure after changes to app

### DIFF
--- a/roles/mini-apps-ui/templates/configmap.yaml.j2
+++ b/roles/mini-apps-ui/templates/configmap.yaml.j2
@@ -5,19 +5,13 @@ metadata:
   name: ui
   namespace: {{ maui_namespace }}
 data:
-  .env: |
+  .env.production: |
     BASE_URL='https://{{ maui_hostname }}'
     BASE_PATH='/{{ maui_hostname_path }}'
 
-    URL=$BASE_URL$BASE_PATH
-
     DATA_MANAGER_API_SERVER='https://{{ maui_data_manager_api_address }}'
 
-    NEXT_PUBLIC_AUTH0_PROFILE=$URL/api/auth/me
-    NEXT_PUBLIC_BASE_PATH=$BASE_PATH
-
     AUTH0_SECRET='{{ maui_auth0_secret }}'
-
     KEYCLOAK_URL='{{ keycloak_server_url }}'
     KEYCLOAK_CLIENT_ID='{{ maui_keycloak_client_id }}'
     KEYCLOAK_CLIENT_SECRET='{{ maui_keycloak_client_secret }}'


### PR DESCRIPTION
I've updated the `.env` created. It is now named `.env.production` to not conflict with the `.env` now used by the app. 

The provided variables are also simplified to match what is needed by the app.